### PR TITLE
Make clause parameter of ipasir2_set_learn() pointer-to-const

### DIFF
--- a/ipasir2.h
+++ b/ipasir2.h
@@ -408,7 +408,7 @@ IPASIR_API ipasir2_errorcode ipasir2_set_terminate(void* solver, void* data, int
  * The ipasir2_set_learn function can be called in any state of the solver, 
  * the state remains unchanged after the call. 
  * 
- * The callback function is of the form "void learn(void* data, int* clause)"
+ * The callback function has the signature "void learn(void* data, int32_t const* clause)"
  *   - the solver calls the callback function with the parameter "data"
  *     having the value passed in the 2nd parameter of the ipasir2_set_learn() function.
  *   - the argument "clause" is a pointer to a null terminated integer array 
@@ -429,7 +429,7 @@ IPASIR_API ipasir2_errorcode ipasir2_set_terminate(void* solver, void* data, int
  * Required state: INPUT or SAT or UNSAT
  * State after: INPUT or SAT or UNSAT
  */
-IPASIR_API ipasir2_errorcode ipasir2_set_learn(void* solver, void* data, void (*learned)(void* data, int32_t* clause));
+IPASIR_API ipasir2_errorcode ipasir2_set_learn(void* solver, void* data, void (*learned)(void* data, int32_t const* clause));
 
 #ifdef __cplusplus
 }  // closing extern "C"

--- a/legacy/ipasir1ipasir2.cc
+++ b/legacy/ipasir1ipasir2.cc
@@ -13,6 +13,102 @@
 #include "ipasir.h"
 #include "ipasir2.h"
 
+#include <new>
+#include <stdexcept>
+#include <vector>
+
+
+namespace {
+using learn_callback_fn = void(*)(void* data, int32_t* clause);
+
+class ipasir2_solver
+{
+public:
+    ipasir2_solver() {
+        if (ipasir2_init(&m_solver) != IPASIR_E_OK) {
+            throw std::runtime_error("ipasir_init() failed");
+        }
+    }
+
+    ~ipasir2_solver() {
+        if (m_solver != nullptr) {
+            ipasir2_release(m_solver);
+        }
+    }
+
+    void add(int32_t lit_or_zero) {
+        ipasir2_add(m_solver, lit_or_zero);
+    }
+
+    void assume(int32_t lit) {
+        ipasir2_assume(m_solver, lit);
+    }
+
+    int32_t solve() {
+        int32_t result = 0;
+        if (ipasir2_solve(m_solver, &result) == IPASIR_E_OK) {
+            return result;
+	}
+        return 0;
+    }
+
+    int32_t val(int32_t lit) {
+        int32_t result = 0;
+        ipasir2_val(m_solver, lit, &result);
+        return result;
+    }
+
+    int32_t failed(int32_t lit) {
+        int32_t result = 0;
+        ipasir2_failed(m_solver, lit, &result);
+        return result;
+    }
+
+    void set_terminate(void* data, int(*terminate)(void* data)) {
+        ipasir2_set_terminate(m_solver, data, terminate);
+    }
+
+    void set_learn(void* data, learn_callback_fn learn_fn) {
+        m_learn_callback = learn_fn;
+        m_learn_callback_data = data;
+
+	// The noexcept specifier is a quickfix, making sure that no exception is thrown into the
+	// callback's callsite (which might not be C++). However, this causes std::terminate to be
+	// called instead. Possible alternatives:
+	// - keep a failure flag and return 0 from solve() if that flag is true
+	// - or silently dropping learnt clauses when an error occurs
+        ipasir2_set_learn(m_solver, static_cast<void*>(this), [](void* data, int32_t const* clause) noexcept {
+            ipasir2_solver* this_ = static_cast<ipasir2_solver*>(data);
+            this_->copy_learnt_clause(clause);
+            this_->m_learn_callback(this_->m_learn_callback_data, this_->m_last_learnt_clause.data());
+        });
+    }
+
+private:
+    void copy_learnt_clause(int32_t const* clause) {
+        int32_t const* cursor = clause;
+        m_last_learnt_clause.clear();
+
+        while(*cursor != 0) {
+            m_last_learnt_clause.push_back(*cursor);
+            ++cursor;
+        }
+
+        m_last_learnt_clause.push_back(0);
+    }
+
+    void* m_solver = nullptr;
+
+    learn_callback_fn m_learn_callback = nullptr;
+    void* m_learn_callback_data = nullptr;
+    std::vector<int> m_last_learnt_clause;
+};
+
+
+ipasir2_solver* to_ipasir2(void* solver) {
+    return static_cast<ipasir2_solver*>(solver);
+}
+}
 
 const char* ipasir_signature() {
     char const* result;
@@ -21,45 +117,43 @@ const char* ipasir_signature() {
 }
 
 void* ipasir_init() {
-    void* result;
-    ipasir2_init(&result);
-    return result;
+    try {
+        return static_cast<void*>(new ipasir2_solver());
+    }
+    catch(std::exception const&) {
+        return nullptr;
+    }
 }
 
 void ipasir_release(void* solver) {
-    ipasir2_release(solver);
+    delete to_ipasir2(solver);
 }
 
 void ipasir_add(void* solver, int32_t lit_or_zero) {
-    ipasir2_add(solver, lit_or_zero);
+    to_ipasir2(solver)->add(lit_or_zero);
 }
 
 void ipasir_assume(void* solver, int32_t lit) {
-    ipasir2_assume(solver, lit);
+    to_ipasir2(solver)->assume(lit);
 }
 
 int ipasir_solve(void* solver) {
-    int result;
-    ipasir2_solve(solver, &result);
-    return result;
+    return to_ipasir2(solver)->solve();
 }
 
 int32_t ipasir_val(void* solver, int32_t lit) {
-    int32_t val;
-    ipasir2_val(solver, lit, &val);
-    return val;
+    return to_ipasir2(solver)->val(lit);
 }
 
 int ipasir_failed(void* solver, int32_t lit) {
-    int failed;
-    ipasir2_failed(solver, lit, &failed);
-    return failed;
+    return to_ipasir2(solver)->failed(lit);
 }
 
 void ipasir_set_terminate(void* solver, void* data, int(*terminate)(void* data)) {
-    ipasir2_set_terminate(solver, data, terminate);
+    to_ipasir2(solver)->set_terminate(data, terminate);
 }
 
-void ipasir_set_learn(void* solver, void* data, int max_length, void(*learned)(void* data, int32_t* clause)) {
-    ipasir2_set_learn(solver, data, learned);
+void ipasir_set_learn(void* solver, void* data, int /*max_length*/, void(*learned)(void* data, int32_t* clause)) {
+    to_ipasir2(solver)->set_learn(data, learned);
 }
+

--- a/util/inspect.cc
+++ b/util/inspect.cc
@@ -89,7 +89,7 @@ void probe_availability_of_callbacks(void* solver) {
 
     print_available("ipasir2_set_terminate()", err);
 
-    err = ipasir2_set_learn(solver, data, [](void* data, int32_t* clause) {
+    err = ipasir2_set_learn(solver, data, [](void* data, int32_t const* clause) {
             std::cout << "learned a clause" << std::endl;
         });
 


### PR DESCRIPTION
This PR changes the signature of the callback passed to ipasir2_set_learn() to `void(void* data, int32_t const* clause)`. The `clause` parameter had been `int32_t*` in IPASIR 1. This allowed client code to modify the clauses exposed by the solver.

Unfortunately this change requires some additional boilerplate code in the ipasir1->ipasir2 bridge. There's an issue with possible bad_alloc exceptions thrown when the learnt clause buffer is extended. For now, the program just terminates if an exception is thrown in the callback, but I think adding a failure flag to the class would be a good idea: if any ipasir2 function fails, set the failure flag, stop forwarding calls to ipasir2 and return 0 from ipasir_solve().

Together with #23, this addresses #13.
